### PR TITLE
Convert XML files from MECA PDF; format; correct validation problems

### DIFF
--- a/examples/article.xml
+++ b/examples/article.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD
+v1.2 20190208//EN" "https://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd">
+<article dtd-version="1.2" article-type="Original Study">
+  <front>
+    <article-meta>
+      <article-id pub-id-type="manuscript">AmyTest-81-10-286</article-id>
+      <article-id pub-id-type="doi">10.1234/91.1191023</article-id>
+      <article-categories>
+        <subj-group subj-group-type="Article Type">
+          <subject id="rapid_comm">Rapid Communication</subject>
+        </subj-group>
+        <subj-group subj-group-type="Category">
+          <subject>Medical Sciences</subject>
+        </subj-group>
+        <subj-group subj-group-type="Classification">
+          <subject vocab-term-identifier="100.1">Medical Sciences</subject>
+          <subject vocab-term-identifier="100.1.3">Anatomy and Pathology</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>Use case testing</article-title>
+        <alt-title alt-title-type="running-head">This is where the short title or running title goes</alt-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author" corresp="yes" specific-use="submitting">
+          <string-name>
+            <given-names>Patrick</given-names>
+            <surname>McCaw</surname>
+          </string-name>
+          <role content-type="1"/>
+          <role vocab="credit" vocab-identifier="http://dictionary.casrai.org/Contributor_Roles" vocab-term="Investigation" vocab-term-identifier="https://dictionary.casrai.org/Contributor_Roles/Investigation" specific-use="Lead">Data Collection</role>
+          <contrib-id contrib-id-type="internal">99999</contrib-id>
+          <contrib-id contrib-id-type="orcid" specific-use="authenticated">0000-0003-2141-4459</contrib-id>
+          <contrib-id contrib-id-type="isni"> 1234</contrib-id>
+          <contrib-id contrib-id-type="pubmed">5678 1</contrib-id>
+          <contrib-id contrib-id-type="researcherid">9999</contrib-id>
+          <contrib-id contrib-id-type="scopusid">8888</contrib-id>
+          <xref ref-type="aff" rid="aff1"/>
+        </contrib>
+        <contrib contrib-type="author">
+          <string-name>
+            <given-names>Fred</given-names>
+            <surname>Vanvleet</surname>
+          </string-name>
+          <role vocab="credit" vocab-identifier="http://dictionary.casrai.org/Contributor_Roles" vocab-term="Investigation" vocab-term-identifier="https://dictionary.casrai.org/Contributor_Roles/Investigation">Data Collection</role>
+          <contrib-id contrib-id-type="internal">4567</contrib-id>
+          <contrib-id contrib-id-type="orcid" specific-use="authenticated">0000-0003-2395-4862</contrib-id>
+          <contrib-id contrib-id-type="isni">ISNI 101</contrib-id>
+          <contrib-id contrib-id-type="pubmed">PubMed 101</contrib-id>
+          <contrib-id contrib-id-type="researcherid">ResearcherID 101</contrib-id>
+          <contrib-id contrib-id-type="scopusid">Scopus 101</contrib-id>
+          <xref ref-type="aff" rid="aff2"/>
+        </contrib>
+        <aff id="aff1">
+          <institution-wrap>
+            <institution>Massachusetts Institution of Technology</institution>
+            <institution-id institution-id-type="Ringgold">12345</institution-id>
+          </institution-wrap>
+          <institution content-type="dept">Department in this spot</institution>
+          <addr-line content-type="addrline1">200 Sutton St</addr-line>
+          <addr-line content-type="addrline2">Suite 304</addr-line>
+          <addr-line content-type="addrline3">Room 5</addr-line>
+          <addr-line content-type="addrline4">Maildrop 501</addr-line>
+          <country specific-use="GB">United Kingdom</country>
+          <addr-line content-type="city">North Andover</addr-line>
+          <addr-line content-type="state">Ma</addr-line>
+          <addr-line content-type="zipcode">01845</addr-line>
+          <fax>978-975-3811</fax>
+          <phone>978-975-7570</phone>
+        </aff>
+        <aff id="aff2">
+          <institution>Tufts University</institution>
+          <institution content-type="position">Professor of Veterinary Medicine</institution>
+          <institution content-type="dept">Physical Therapy</institution>
+          <addr-line content-type="addrline1">175 Hydrangea Street</addr-line>
+          <addr-line content-type="addrline2">Suite 3</addr-line>
+          <addr-line content-type="addrline3">Unit 304</addr-line>
+          <addr-line content-type="addrline4">Maildrop 13</addr-line>
+          <fax>978-975-3811</fax>
+          <phone>978-975-7570</phone>
+          <country specific-use="us">UNITED STATES</country>
+          <addr-line content-type="city">Atkinson</addr-line>
+          <addr-line content-type="state">NH</addr-line>
+          <addr-line content-type="zipcode">03873</addr-line>
+        </aff>
+      </contrib-group>
+      <history/>
+      <abstract>
+        <p>This is the manuscript abstract as a separate field outside of the word doc</p>
+      </abstract>
+      <kwd-group>
+        <kwd>Burndown</kwd>
+        <kwd>glyphosate resistance</kwd>
+        <kwd>herbicide efficacy</kwd>
+        <kwd>herbicide mixtures</kwd>
+        <kwd>plant density</kwd>
+        <kwd>weed resistance</kwd>
+        <kwd>yield reduction</kwd>
+      </kwd-group>
+      <funding-group>
+        <award-group>
+          <funding-source>
+            <institution-wrap>
+              <institution>National Institutes of Health (US)</institution>
+              <institution-id institution-id-type="doi" vocab="open-funder-registry" vocab-identifier="10.13039/open-funder-registry">10.13039/100000002</institution-id>
+            </institution-wrap>
+            <named-content content-type="funder-id">http://dx.doi.org/10.13039/100001234</named-content>
+          </funding-source>
+          <award-id>grant number goes here</award-id>
+          <principal-award-recipient>
+            <name>
+              <surname>Carberry</surname>
+              <given-names>Josiah Stinkney</given-names>
+            </name>
+            <!-- Only use the @authenticated="true" attribute if the ORCID has been collected using the ORCID
+login and validation step and has not been copy and pasted at any point in the workflow. If this is not
+the case the value should be set to "false" -->
+            <contrib-id contrib-id-type="orcid" authenticated="true">https://orcid.org/0000-0002-1825-0097</contrib-id>
+          </principal-award-recipient>
+        </award-group>
+        <award-group>
+          <funding-source>Radcliffe Institute for Advanced Study, Harvard University<named-content content-type="funder-id">http://dx.doi.org/10.13039/100006274</named-content></funding-source>
+          <principal-award-recipient>Joe Smith</principal-award-recipient>
+        </award-group>
+      </funding-group>
+      <counts>
+        <count count-type="image-bw" count="3"/>
+        <count count-type="image-color" count="3"/>
+        <fig-count count="0"/>
+      </counts>
+      <custom-meta-group>
+        <custom-meta specific-use="Additional Manuscript Detail" id="online_only">
+          <meta-name>Online Only Figures</meta-name>
+          <meta-value>Yes</meta-value>
+        </custom-meta>
+        <custom-meta>
+          <meta-name>Manuscript Notes</meta-name>
+          <meta-value>These are some manuscript notes from the exporting system which will be imported into EM's manuscript notes field if present in the XML.</meta-value>
+        </custom-meta>
+        <custom-meta>
+          <meta-name>Production Notes</meta-name>
+          <meta-value>These are some Production Notes</meta-value>
+        </custom-meta>
+        <!-- The following custom-meta tags illustrate the tagging to be used to ingest a custom
+question response for the Corresponding Author. The value of the "id" attribute must contain the
+Custom Metadata ID configured on the EM site. The value of the specific-use attribute must be
+hardcoded to "question" for a parent-level question. -->
+        <custom-meta id="conflict" specific-use="question">
+          <meta-name>Question text or a portion of the question text is written here</meta-name>
+          <meta-value>Corresponding Author's response is written here. If the question has multiple responses, each response is separated by a pipe character e.g. red|blue|yellow</meta-value>
+        </custom-meta>
+        <!-- The following custom-meta tags illustrate the tagging to be used to ingest a custom
+question response for the Corresponding Author, that is a response to a follow-up question. The
+value of the "id" attribute must contain the Custom Metadata ID configured for the follow-up question
+on the EM site. The value of the specific-use attribute must be hardcoded to question: (including the
+colon :) followed by the Custom Metadata ID value of the parent-level question. In the sample shown,
+the question with the id "coi_details" is a follow-up question to the parent question with the Custom
+Metadata ID "conflict", and the question with the id "coi_more_info" is a follow-up question to its
+parent which has the Custom Metadata ID "coi_details" [its parent is a follow-up question to the top
+level question] -->
+        <custom-meta id="coi_details" specific-use="question_follow-up-to:conflict">
+          <meta-name>The follow-up question text or a portion of the follow-up question text is written here</meta-name>
+          <meta-value>Corresponding Author's response to the follow-up question is written here. If the follow-up question has multiple responses, each response is separated by a pipe character e.g. orange|green|violet</meta-value>
+        </custom-meta>
+        <custom-meta id="coi_more_info" specific-use="question_follow-up-to:coi_details">
+          <meta-name>The 2nd level follow-up question text or a portion of the 2nd level follow-up question text is written here</meta-name>
+          <meta-value>Corresponding Author's response to the 2nd level follow-up question is written here. If the follow-up question has multiple responses, each response is separated by a pipe character</meta-value>
+        </custom-meta>
+      </custom-meta-group>
+    </article-meta>
+  </front>
+  <body/>
+</article>

--- a/examples/manifest.xml
+++ b/examples/manifest.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE manifest PUBLIC "-//MECA//DTD Manifest v1.0//en" "../schema/manifest-1.0.dtd">
+<manifest xmlns="https://manuscriptexchange.org/schema/manifest" xmlns:xlink="http://www.w3.org/1999/xlink" manifest-version="1">
+  <item id="random-identifier1" item-type="article-metadata">
+    <item-description>This is the article.xml file that contains the submission's metadata</item-description>
+    <instance media-type="application/xml" xlink:href="DEMO151_D-18-01229.xml"/>
+  </item>
+  <item id="random-identifier2" item-type="review-metadata">
+    <item-description>This is the review xml file that contains the submission's metadata</item-description>
+    <instance media-type="application/xml" xlink:href="DEMO151_D-18-01229_Reviews.xml"/>
+  </item>
+  <item id="random-identifier3" item-type="transfer-metadata">
+    <item-description>This is the transfer xml file that contains information about the source and destination</item-description>
+    <instance media-type="application/xml" xlink:href="DEMO151_D-18-01229_Transfer.xml"/>
+  </item>
+  <item id="a-222" item-type="manuscript" item-version="0">
+    <item-description>This is the manuscript submitted by the author</item-description>
+    <file-order>5</file-order>
+    <instance media-type="application/vnd.openxmlformats-officedocument.wordprocessingml.document" xlink:href="Manuscript.docx"/>
+  </item>
+  <item id="a-123" item-type="author agreement" item-version="0">
+    <item-description>Author Agreement</item-description>
+    <file-order>1</file-order>
+    <instance media-type="application/vnd.openxmlformats-officedocument.wordprocessingml.document" xlink:href="assignmentofrights.docx"/>
+  </item>
+  <item id="a-456" item-type="Reviewer Response">
+    <item-description>This is the file the Author uploaded in response to comments by reviewers</item-description>
+    <instance media-type="application/msword" xlink:href="Responses.doc"/>
+  </item>
+  <item id="b-456" item-type="figure" item-version="0">
+    <item-description>Figure</item-description>
+    <file-order>3</file-order>
+    <item-metadata>
+      <metadata metadata-name="Figure Number">1</metadata>
+      <metadata metadata-name="Caption">This is the caption for Figure 1</metadata>
+    </item-metadata>
+    <instance media-type="image/jpeg" xlink:href="wrist_scaphoidvx_diagnosis.jpg"/>
+  </item>
+  <item id="c-567" item-type="figure" item-version="1">
+    <item-description>Figure</item-description>
+    <file-order>4</file-order>
+    <instance media-type="image/jpeg" xlink:href="wrist_scaphoidfx_causes.jpg"/>
+  </item>
+  <item id="d-891" item-type="supplemental">
+    <item-description>Supplementary Data File</item-description>
+    <instance media-type="text/plain" xlink:href="https://landsat-pds.s3.amazonaws.com/c1/L8/139/045/LC08_L1TP_139045_20170304_20170316_01_T1/index.html"/>
+  </item>
+  <item item-type="Author/Editor PDF" item-version="0">
+    <item-description>Working PDF</item-description>
+    <instance media-type="application/pdf" xlink:href="DEMO151_D-18-01229.PDF"/>
+  </item>
+  <item id="e-123" item-type="Manuscript" item-version="1">
+    <item-description>This is an arXiv file uploaded by the Author</item-description>
+    <file-order>2</file-order>
+    <item-metadata>
+      <metadata metadata-name="Includes References">Yes</metadata>
+    </item-metadata>
+    <instance media-type="application/x-tex" xlink:href="ehII_180124.tex"/>
+  </item>
+  <item id="f-345" item-type="Reviewer Attachment">
+    <item-description>This is an annotated file uploaded by the Reviewer</item-description>
+    <instance media-type="application/msword" xlink:href="annotated-review.docx"/>
+  </item>
+  <item id="custom-metadata-id-7" item-type="Author Proof">
+    <item-description>This is a production file</item-description>
+    <instance media-type="application/xml" xlink:href="marked-up-manuscript.xml"/>
+  </item>
+</manifest>

--- a/examples/reviews.xml
+++ b/examples/reviews.xml
@@ -1,0 +1,545 @@
+<?xml version="1.0"?>
+<!DOCTYPE review-group PUBLIC "-//MECA//DTD Reviews v1.0//en" "../schema/reviews-1.0.dtd">
+<review-group xmlns="https://manuscriptexchange.org/schema/reviews" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" content-version="0">
+  <review review-type="review" review-version="0">
+    <review-item-group>
+      <review-item review-item-type="recommendation" is-confidential="yes" sequence-number="">
+        <review-item-question>
+          <title>Rating 1</title>
+          <alt-title/>
+          <text>Recommendation Term</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Reject and Transfer</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" is-confidential="yes">
+        <review-item-question>
+          <title>Comments 1</title>
+          <alt-title/>
+          <text>Comments to Editor</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>This is a great paper but not for this journal.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title>Comments 2</title>
+          <alt-title/>
+          <text>Comments to Author</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Nice job but needs some work.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="1">
+        <review-item-question>
+          <title>Rating 2</title>
+          <alt-title/>
+          <text>On a scale of 1 to 10, how "novel" is the idea presented in this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>5</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="2">
+        <review-item-question>
+          <title>Rating 3</title>
+          <alt-title/>
+          <text>How would you best describe this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Average</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="multiple-choice" sequence-number="3">
+        <review-item-question>
+          <title>Survey 1</title>
+          <alt-title/>
+          <text>What is your favorite color?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Red</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Blue</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Yellow</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="file" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Supplemental Info 1</title>
+          <alt-title/>
+          <text>Reviewer Attachment</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data/>
+          <ext-link xlink:href="my manuscript.docx" xlink:title="description of the file"/>
+        </review-item-response>
+      </review-item>
+    </review-item-group>
+    <date date-type="submitted">
+      <year>2018</year>
+      <month>2</month>
+      <day>28</day>
+    </date>
+    <date date-type="due">
+      <year>2018</year>
+      <month>2</month>
+      <day>14</day>
+    </date>
+    <date date-type="assigned">
+      <year>2018</year>
+      <month>1</month>
+      <day>29</day>
+    </date>
+    <contrib-group>
+      <contrib contrib-type="reviewer">
+        <name>
+          <surname>Reviewer</surname>
+          <given-names>Bob</given-names>
+          <prefix>Dr.</prefix>
+        </name>
+        <contrib-id contrib-id-type="orcid">1234-0052-2141-3325</contrib-id>
+        <degrees>PhD</degrees>
+        <email>BReviewer@mit.edu</email>
+        <xref ref-type="aff" rid="aff1"/>
+      </contrib>
+      <aff id="aff1">
+        <institution-wrap>
+          <institution>Massachusetts Institution of Technology</institution>
+          <institution-id institution-id-type="Ringgold">12345</institution-id>
+        </institution-wrap>
+        <institution content-type="dept">Physics Department</institution>
+        <addr-line content-type="addrline1">77 Massachusetts Avenue</addr-line>
+        <addr-line content-type="addrline2">Suite 304</addr-line>
+        <addr-line content-type="addrline3">Room 5</addr-line>
+        <addr-line content-type="addrline4">Maildrop 501</addr-line>
+        <addr-line content-type="city">Cambridge</addr-line>
+        <addr-line content-type="state">MA</addr-line>
+        <addr-line content-type="country">United States</addr-line>
+        <addr-line content-type="country-code">us</addr-line>
+        <addr-line content-type="zip">02139</addr-line>
+        <fax>617-555-2321</fax>
+        <phone>617-253-1000</phone>
+      </aff>
+    </contrib-group>
+    <permissions>
+      <license>
+        <ali:license_ref xmlns:ali="http://www.niso.org/schemas/ali/1.0/" start_date="2019-08-20">http://www.examplesite.org/open_license.html</ali:license_ref>
+      </license>
+    </permissions>
+  </review>
+  <review review-type="review" review-version="0">
+    <review-item-group>
+      <review-item review-item-type="recommendation" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Rating 1</title>
+          <alt-title/>
+          <text>Recommendation Term</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Major Revision</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Comments 1</title>
+          <alt-title/>
+          <text>Comments to Editor</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>This is a great paper but not for this journal.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title>Comments 2</title>
+          <alt-title/>
+          <text>Comments to Author</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Nice job but needs some work.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="1">
+        <review-item-question>
+          <title>Rating 2</title>
+          <alt-title/>
+          <text>On a scale of 1 to 10, how "novel" is the idea presented in this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>5</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="2">
+        <review-item-question>
+          <title>Rating 3</title>
+          <alt-title/>
+          <text>How would you describe this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Average</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="multiple-choice" sequence-number="3">
+        <review-item-question>
+          <title/>
+          <alt-title/>
+          <text>What is your favorite color?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Red</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Blue</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Green</review-item-data>
+        </review-item-response>
+      </review-item>
+    </review-item-group>
+    <date date-type="submitted">
+      <year>2018</year>
+      <month>2</month>
+      <day>28</day>
+    </date>
+    <date date-type="due">
+      <year>2018</year>
+      <month>2</month>
+      <day>14</day>
+    </date>
+    <date date-type="assigned">
+      <year>2018</year>
+      <month>1</month>
+      <day>29</day>
+    </date>
+    <contrib-group>
+      <contrib contrib-type="reviewer">
+        <name>
+          <surname>Rabbit</surname>
+          <given-names>Roger</given-names>
+          <prefix>Dr.</prefix>
+        </name>
+        <!-- If the Reviewer does not have an authenticated ORCID do not
+write the <contrib-id> element to the XML file-->
+        <contrib-id/>
+        <degrees>PhD</degrees>
+        <email>BReviewer@ucr.edu</email>
+        <xref ref-type="aff" rid="aff2"/>
+      </contrib>
+      <aff id="aff2">
+        <institution-wrap>
+          <institution>University of California Riverside</institution>
+          <institution-id institution-id-type="Ringgold">8790</institution-id>
+        </institution-wrap>
+        <institution content-type="dept">Department of Psychology</institution>
+        <addr-line content-type="addrline1">900 University Avenue</addr-line>
+        <addr-line content-type="addrline2">Suite 304</addr-line>
+        <addr-line content-type="addrline3">Room 7</addr-line>
+        <addr-line content-type="addrline4">Maildrop 501</addr-line>
+        <addr-line content-type="city">Riverside</addr-line>
+        <addr-line content-type="state">CA</addr-line>
+        <addr-line content-type="country">United States</addr-line>
+        <addr-line content-type="country-code">us</addr-line>
+        <addr-line content-type="zip">92521</addr-line>
+        <fax>951-555-2321</fax>
+        <phone>951-827-1012</phone>
+      </aff>
+    </contrib-group>
+    <permissions>
+      <copyright-statement>Copyright &#xA9; 2018, Dr. Roger Rabbit, all rights reserved.</copyright-statement>
+      <copyright-year>2018</copyright-year>
+      <copyright-holder>Dr. Roger Rabbit</copyright-holder>
+    </permissions>
+  </review>
+  <review review-type="decision" review-version="1">
+    <review-item-group>
+      <review-item review-item-type="decision" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title/>
+          <alt-title/>
+          <text>Final Decision</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Reject and Transfer</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" is-confidential="yes" sequence-number="">
+        <review-item-question>
+          <title>Comments 1</title>
+          <alt-title/>
+          <text>Comments to Editor</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>I recommend that we transfer this paper to a sister publication.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title>Comments 2</title>
+          <alt-title/>
+          <text>Comments to Author</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Nice job but needs some work. Please resubmit to Journal ABC</review-item-data>
+        </review-item-response>
+      </review-item>
+    </review-item-group>
+    <date date-type="submitted">
+      <year>2018</year>
+      <month>2</month>
+      <day>28</day>
+    </date>
+    <contrib-group>
+      <contrib contrib-type="Editor-in-Chief">
+        <name>
+          <surname>Editor</surname>
+          <given-names>Sally</given-names>
+          <prefix>Dr.</prefix>
+        </name>
+        <contrib-id contrib-id-type="orcid">0000-0003-2141-4459</contrib-id>
+        <degrees>PhD</degrees>
+        <email>SEditor@mit.edu</email>
+        <xref ref-type="aff" rid="aff3"/>
+      </contrib>
+      <aff id="aff3">
+        <institution-wrap>
+          <institution>Massachusetts Institution of Technology</institution>
+          <institution-id institution-id-type="Ringgold">12345</institution-id>
+        </institution-wrap>
+        <institution content-type="dept">Physics Department</institution>
+        <addr-line content-type="addrline1">77 Massachusetts Avenue</addr-line>
+        <addr-line content-type="addrline2">Suite 500</addr-line>
+        <addr-line content-type="addrline3">Room 1</addr-line>
+        <addr-line content-type="addrline4">Maildrop 714</addr-line>
+        <addr-line content-type="city">Cambridge</addr-line>
+        <addr-line content-type="state">MA</addr-line>
+        <addr-line content-type="country">United States</addr-line>
+        <addr-line content-type="country-code">us</addr-line>
+        <addr-line content-type="zip">02139</addr-line>
+        <fax>617-555-2321</fax>
+        <phone>617-253-1050</phone>
+      </aff>
+    </contrib-group>
+    <permissions>
+      <license>
+        <ali:license_ref xmlns:ali="http://www.niso.org/schemas/ali/1.0/" start_date="2018-02-28"/>
+      </license>
+    </permissions>
+  </review>
+  <review review-type="review" review-version="1">
+    <review-item-group>
+      <review-item review-item-type="recommendation" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Rating 1</title>
+          <alt-title/>
+          <text>Recommendation Term</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Reject and Transfer</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Comments 1</title>
+          <alt-title/>
+          <text>Comments to Editor</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>This is a great paper but not for this journal.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title>Comments 2</title>
+          <alt-title/>
+          <text>Comments to Author</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Nice job but needs some work.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="1">
+        <review-item-question>
+          <title>Rating 2</title>
+          <alt-title/>
+          <text>On a scale of 1 to 10, how "novel" is the idea presented in this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>5</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="2">
+        <review-item-question>
+          <title>Rating 3</title>
+          <alt-title/>
+          <text>How would you describe this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Awful</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="multiple-choice" sequence-number="3">
+        <review-item-question>
+          <title>Survey 1</title>
+          <alt-title/>
+          <text>What is your favorite color?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Red</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Blue</review-item-data>
+        </review-item-response>
+        <review-item-response>
+          <review-item-data>Yellow</review-item-data>
+        </review-item-response>
+      </review-item>
+    </review-item-group>
+    <contrib-group>
+      <contrib contrib-type="Reviewer">
+        <name>
+          <surname>Reviewer</surname>
+          <given-names>Bob</given-names>
+          <prefix>Dr.</prefix>
+        </name>
+        <contrib-id contrib-id-type="orcid">1234-0052-2141-3325</contrib-id>
+        <degrees>PhD</degrees>
+        <email>BReviewer@mit.edu</email>
+        <xref ref-type="aff" rid="aff4"/>
+      </contrib>
+      <aff id="aff4">
+        <institution-wrap>
+          <institution>Massachusetts Institution of Technology</institution>
+          <institution-id institution-id-type="Ringgold">12345</institution-id>
+        </institution-wrap>
+        <institution content-type="dept">Physics Department</institution>
+        <addr-line content-type="addrline1">77 Massachusetts Avenue</addr-line>
+        <addr-line content-type="addrline2">Suite 304</addr-line>
+        <addr-line content-type="addrline3">Room 5</addr-line>
+        <addr-line content-type="addrline4">Maildrop 501</addr-line>
+        <addr-line content-type="city">Cambridge</addr-line>
+        <addr-line content-type="state">MA</addr-line>
+        <addr-line content-type="country">United States</addr-line>
+        <addr-line content-type="country-code">us</addr-line>
+        <addr-line content-type="zip">02139</addr-line>
+        <fax>617-555-2321</fax>
+        <phone>617-253-1000</phone>
+      </aff>
+    </contrib-group>
+  </review>
+  <review review-type="review" review-version="1">
+    <review-item-group>
+      <review-item review-item-type="recommendation" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Rating 1</title>
+          <alt-title/>
+          <text>Recommendation Term</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Reject and Transfer</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="yes">
+        <review-item-question>
+          <title>Comments 1</title>
+          <alt-title/>
+          <text>Comments to Editor</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>This is a great paper but not for this journal.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="comments" sequence-number="" is-confidential="no">
+        <review-item-question>
+          <title>Comments 2</title>
+          <alt-title/>
+          <text>Comments to Author</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>Nice job but needs some work.</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="1">
+        <review-item-question>
+          <title>Rating 2</title>
+          <alt-title/>
+          <text>On a scale of 1 to 10, how "novel" is the idea presented in this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>5</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="rating" sequence-number="2">
+        <review-item-question>
+          <title>Rating 3</title>
+          <alt-title/>
+          <text>How would you describe this manuscript?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data review-item-data-type="decimal">9.1</review-item-data>
+        </review-item-response>
+      </review-item>
+      <review-item review-item-type="text" sequence-number="3">
+        <review-item-question>
+          <title>Comments 3</title>
+          <alt-title/>
+          <text>When are you planning to revise this paper?</text>
+        </review-item-question>
+        <review-item-response>
+          <review-item-data>08/27/2025</review-item-data>
+        </review-item-response>
+      </review-item>
+    </review-item-group>
+    <date date-type="submitted">
+      <year>2018</year>
+      <month>2</month>
+      <day>28</day>
+    </date>
+    <date date-type="due">
+      <year>2018</year>
+      <month>2</month>
+      <day>14</day>
+    </date>
+    <date date-type="assigned">
+      <year>2018</year>
+      <month>1</month>
+      <day>29</day>
+    </date>
+    <contrib-group>
+      <contrib contrib-type="Reviewer">
+        <name>
+          <surname>Rabbit</surname>
+          <given-names>Roger</given-names>
+          <prefix>Dr.</prefix>
+        </name>
+        <contrib-id contrib-id-type="orcid">1234-0052-2141-3325</contrib-id>
+        <degrees>PhD</degrees>
+        <email>BReviewer@mit.edu</email>
+        <xref ref-type="aff" rid="aff5"/>
+      </contrib>
+      <aff id="aff5">
+        <institution-wrap>
+          <institution>University of California Riverside</institution>
+          <institution-id institution-id-type="Ringgold">8790</institution-id>
+        </institution-wrap>
+        <institution content-type="dept">Department of Psychology</institution>
+        <addr-line content-type="addrline1">900 University Avenue</addr-line>
+        <addr-line content-type="addrline2">Suite 304</addr-line>
+        <addr-line content-type="addrline3">Room 7</addr-line>
+        <addr-line content-type="addrline4">Maildrop 501</addr-line>
+        <addr-line content-type="city">Riverside</addr-line>
+        <addr-line content-type="state">CA</addr-line>
+        <addr-line content-type="country">United States</addr-line>
+        <addr-line content-type="country-code">us</addr-line>
+        <addr-line content-type="zip">92521</addr-line>
+        <fax>951-555-2321</fax>
+        <phone>951-827-1012</phone>
+      </aff>
+    </contrib-group>
+  </review>
+</review-group>

--- a/examples/transfer.xml
+++ b/examples/transfer.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!DOCTYPE transfer PUBLIC "-//MECA//DTD Transfer v1.0//en" "../schema/transfer-1.0.dtd">
+<transfer xmlns="https://manuscriptexchange.org/schema/transfer" transfer-version="1.0">
+  <transfer-source>
+    <service-provider>
+      <provider-name>Aries Systems</provider-name>
+      <contact>
+        <contact-name>
+          <surname>Smith</surname>
+          <given-names>Mary</given-names>
+        </contact-name>
+        <email>MarySmith@sample.email</email>
+        <phone>444-555-0101</phone>
+      </contact>
+    </service-provider>
+    <publication type="journal">
+      <publication-title>The Journal of the American Medical Association</publication-title>
+      <acronym>JAMA</acronym>
+      <contact>
+        <email>MyJournal@ariessys.com</email>
+      </contact>
+    </publication>
+  </transfer-source>
+  <destination>
+    <service-provider>
+      <provider-name>Highwire</provider-name>
+      <contact contact-role="Project Manager">
+        <contact-name>
+          <surname>Rogers</surname>
+          <given-names>John</given-names>
+        </contact-name>
+        <email>jrogers@highwire.com</email>
+        <phone>444-555-1212</phone>
+      </contact>
+    </service-provider>
+    <publication type="preprint-server">
+      <publication-title>bioRxiv</publication-title>
+      <acronym>bioRxiv</acronym>
+      <contact contact-role="Managing Editor">
+        <contact-name>
+          <surname>Rogers</surname>
+          <given-names>Sally</given-names>
+        </contact-name>
+        <email>srogers@bioarxiv.com</email>
+        <phone>301-555-1212</phone>
+      </contact>
+    </publication>
+    <security>
+      <authentication-code>abdasa-13123-abae</authentication-code>
+    </security>
+  </destination>
+  <processing-instructions>
+    <processing-instruction processing-sequence="1">Verify XML First</processing-instruction>
+    <processing-instruction processing-sequence="2">Load XML</processing-instruction>
+    <processing-comments>Free form comments</processing-comments>
+  </processing-instructions>
+</transfer>

--- a/schema/manifest-1.0.dtd
+++ b/schema/manifest-1.0.dtd
@@ -1,0 +1,50 @@
+<!-- DOCTYPE manifest PUBLIC "-//MECA//DTD Manifest v1.0//en"
+"https://www.manuscriptexchange.org/schema/manifest-1.0.dtd"
+-->
+
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTER MODULES -->
+
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any standard XML special character
+entities used in this DTD
+-->
+<!ENTITY % xmlspecchars.ent
+PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+"JATS-xmlspecchars1.ent"
+>
+
+<!-- CUSTOM SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any custom special character
+entities created for this Suite
+-->
+<!ENTITY % chars.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2
+20190208//EN"
+"JATS-chars1.ent"
+>
+<!ELEMENT manifest (item+)>
+<!ATTLIST manifest xmlns CDATA #FIXED "https://manuscriptexchange.org/schema/manifest">
+<!ATTLIST manifest xmlns:xlink CDATA #FIXED "http://www.w3.org/1999/xlink">
+<!ATTLIST manifest manifest-version CDATA #REQUIRED>
+<!ELEMENT item (item-title?, item-description?, file-order?, item-metadata?, instance+)>
+<!ATTLIST item id ID #IMPLIED>
+<!ATTLIST item item-type CDATA #IMPLIED>
+<!ATTLIST item custom-metadata-id CDATA #IMPLIED>
+<!ATTLIST item item-version CDATA #IMPLIED>
+<!ELEMENT item-title (#PCDATA)>
+<!ELEMENT item-description (#PCDATA)>
+<!ELEMENT file-order (#PCDATA)>
+<!ELEMENT item-metadata (metadata+)>
+<!ELEMENT metadata (#PCDATA)>
+<!ATTLIST metadata metadata-name CDATA #REQUIRED>
+<!ELEMENT instance EMPTY>
+<!ATTLIST instance xmlns:xlink CDATA #FIXED 'http://www.w3.org/1999/xlink' xlink:type (locator) #FIXED 'locator' xlink:href CDATA #REQUIRED>
+<!ATTLIST instance media-type CDATA #IMPLIED>
+<!ATTLIST instance origin CDATA #IMPLIED>
+<!ATTLIST instance conversion CDATA #IMPLIED>
+<!ATTLIST instance composition CDATA #IMPLIED>

--- a/schema/reviews-1.0.dtd
+++ b/schema/reviews-1.0.dtd
@@ -1,0 +1,111 @@
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTER MODULES -->
+
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any standard XML special character
+entities used in this DTD
+-->
+<!ENTITY % xmlspecchars.ent PUBLIC "-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN" "JATS-xmlspecchars1.ent">
+
+<!-- CUSTOM SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any custom special character
+entities created for this Suite
+-->
+<!ENTITY % chars.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2
+20190208//EN"
+"JATS-chars1.ent"
+>
+<!ELEMENT review-group (review+)>
+<!ATTLIST review-group content-version CDATA #IMPLIED xmlns CDATA #FIXED "https://manuscriptexchange.org/schema/reviews" xmlns:xlink CDATA #FIXED "http://www.w3.org/1999/xlink" xmlns:ali CDATA #FIXED "http://www.niso.org/schemas/ali/1.0/">
+<!-- A review encapsulates the work that a reviewer has done to review a particular version of a
+manuscript -->
+<!ELEMENT review (review-item-group, date*, contrib-group?, permissions?)>
+<!ATTLIST review review-version CDATA #IMPLIED>
+<!ATTLIST review review-type (review|recommendation|decision|CDATA) #IMPLIED>
+<!ATTLIST review blinding (single|double|none|CDATA) #IMPLIED>
+<!ATTLIST review permission-to-publish (yes|no) #IMPLIED>
+<!ATTLIST review permission-to-transfer (yes|no) #IMPLIED>
+<!ATTLIST review sequence-id (CDATA) #IMPLIED>
+<!ELEMENT review-item-group (review-item+)>
+<!-- A review-item is a single piece of data gathered for a review. It is fairly flexible but may be (for
+example) a question and answer, question and set of answers, a miscellaneous comment, or an
+attached file. -->
+<!ELEMENT review-item (review-item-question?, review-item-response*)>
+<!ATTLIST review-item sequence-number CDATA #IMPLIED>
+<!ATTLIST review-item is-confidential (yes|no) #IMPLIED>
+<!ATTLIST review-item attended-for (editor|associate-editor|eic|authors|other-reviewers|public|CDATA) #IMPLIED>
+<!ATTLIST review-item review-item-type (decision|recommendation|rating|single-choice|multiple-choice|text|comments|file|correspondence|CDATA) #IMPLIED>
+<!-- A review-item-question is the question part of a review-item. It's used to indicate what
+information a reviewer was asked to provide. -->
+<!ELEMENT review-item-question (review-question-id?, title?, alt-title?, text?)>
+<!ELEMENT review-question-id (#PCDATA)>
+<!ATTLIST review-question-id pub-id-type CDATA #IMPLIED>
+<!ELEMENT title (#PCDATA)>
+<!ELEMENT alt-title (#PCDATA)>
+<!ELEMENT text (#PCDATA)>
+<!-- A review-item-response is the response part of a review-item. It is some single piece of data that
+a reviewer has provided. -->
+<!ELEMENT review-item-response (review-item-data?, ext-link?)>
+<!ELEMENT review-item-data (#PCDATA)>
+<!-- the review-item-data may specify a data type to aid the receiver in processing it. If not, it'll be
+assumed to be raw text. -->
+<!ATTLIST review-item-data review-item-data-type (integer|decimal|date|text) #IMPLIED>
+<!ELEMENT ext-link (#PCDATA)>
+<!ATTLIST ext-link xmlns:xlink CDATA #FIXED "http://www.w3.org/1999/xlink" xlink:href CDATA #REQUIRED xlink:title CDATA #IMPLIED>
+<!-- A date is the date on which some relevant event related to a particular review occurred. For example, when the review was assigned, submitted or due -->
+<!ELEMENT date (year, month, day)>
+<!ELEMENT year (#PCDATA)>
+<!ELEMENT month (#PCDATA)>
+<!ELEMENT day (#PCDATA)>
+<!ATTLIST date date-type (assigned|submitted|due|CDATA) #IMPLIED>
+<!-- A contrib-group contains contact information about a particular reviewer. While it's not syntactically possible to prohibit the inclusion of a stand-alone aff element, having contact information without anybody to associate it with is not very practical. -->
+<!ELEMENT contrib-group (contrib?, aff?)>
+<!-- A contrib is the individual information about a reviewer -->
+<!ELEMENT contrib ((name | name-alternatives)?, contrib-id?, degrees?, email?, xref?)>
+<!ATTLIST contrib contrib-type CDATA #IMPLIED>
+<!ELEMENT name-alternatives (name+)>
+<!ELEMENT name (surname, given-names, prefix?, suffix?)>
+<!ATTLIST name name-style ( western | eastern | islek ) 'western' xml:lang NMTOKEN #IMPLIED>
+<!ELEMENT surname (#PCDATA)>
+<!ELEMENT given-names (#PCDATA)>
+<!ELEMENT prefix (#PCDATA)>
+<!ELEMENT suffix (#PCDATA)>
+<!ELEMENT contrib-id (#PCDATA)>
+<!ATTLIST contrib-id contrib-id-type (isni |orcid| pub-med-author-id| researcher-id| scopus-author-id|custom) #IMPLIED>
+<!ELEMENT degrees (#PCDATA)>
+<!ELEMENT email (#PCDATA)>
+<!-- the xref element of a contrib points to an aff element with the given rid -->
+<!ELEMENT xref EMPTY>
+<!ATTLIST xref ref-type CDATA #IMPLIED>
+<!ATTLIST xref rid IDREF #REQUIRED>
+<!-- An aff element contains information about a reviewer's affiliation -->
+<!ELEMENT aff (#PCDATA|institution-wrap|institution|addr-line|fax|phone)*>
+<!ATTLIST aff id ID #REQUIRED>
+<!ELEMENT institution-wrap (institution, institution-id?)>
+<!ELEMENT institution (#PCDATA)>
+<!ATTLIST institution content-type CDATA #IMPLIED>
+<!ELEMENT institution-id (#PCDATA)>
+<!ATTLIST institution-id institution-id-type CDATA #IMPLIED>
+<!ELEMENT department (#PCDATA)>
+<!ELEMENT addr-line (#PCDATA)>
+<!ATTLIST addr-line content-type (addrline1|addrline2|addrline3|addrline4|city|state|country|country-code|zip|CDATA) #IMPLIED>
+<!ELEMENT fax (#PCDATA)>
+<!ELEMENT phone (#PCDATA)>
+<!ELEMENT permissions (copyright-statement*, copyright-year*, copyright-holder*, (ali:free_to_read | license)*) >
+<!ATTLIST permissions id ID #IMPLIED>
+<!ELEMENT copyright-statement (#PCDATA ) >
+<!ATTLIST copyright-statement id ID #IMPLIED>
+<!ELEMENT copyright-year (#PCDATA)>
+<!ELEMENT copyright-holder (#PCDATA) >
+<!ATTLIST copyright-holder id ID #IMPLIED xml:lang CDATA #IMPLIED >
+<!ELEMENT license (ali:license_ref | license-p)+ >
+<!ATTLIST license id ID #IMPLIED license-type CDATA #IMPLIED xml:lang CDATA #IMPLIED >
+<!ELEMENT license-p (#PCDATA)>
+<!ELEMENT ali:free_to_read EMPTY >
+<!ATTLIST ali:free_to_read xmlns:ali CDATA #FIXED "http://www.niso.org/schemas/ali/1.0/" end_date CDATA #IMPLIED start_date CDATA #IMPLIED>
+<!ELEMENT ali:license_ref (#PCDATA) >
+<!ATTLIST ali:license_ref xmlns:ali CDATA #FIXED "http://www.niso.org/schemas/ali/1.0/" start_date CDATA #IMPLIED>

--- a/schema/transfer-1.0.dtd
+++ b/schema/transfer-1.0.dtd
@@ -1,0 +1,52 @@
+<!-- DOCTYPE transfer PUBLIC "-//MECA//DTD Transfer v1.0//en"
+"https://www.manuscriptexchange.org/schema/transfer-1.0.dtd" -->
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTER MODULES -->
+
+<!-- ============================================================= -->
+<!-- SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any standard XML special character
+entities used in this DTD
+-->
+<!ENTITY % xmlspecchars.ent
+PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.2 20190208//EN"
+"JATS-xmlspecchars1.ent"
+>
+<!-- CUSTOM SPECIAL CHARACTERS DECLARATIONS -->
+<!--
+Declares any custom special character
+entities created for this Suite
+-->
+<!ENTITY % chars.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.2
+20190208//EN"
+"JATS-chars1.ent"
+>
+<!ELEMENT transfer (transfer-source, destination, processing-instructions?)
+>
+<!ATTLIST transfer xmlns CDATA #FIXED "https://manuscriptexchange.org/schema/transfer">
+<!ATTLIST transfer transfer-version CDATA #REQUIRED>
+<!ELEMENT transfer-source (service-provider?, publication, security?)>
+<!ELEMENT service-provider (provider-name?, contact?)>
+<!ELEMENT provider-name (#PCDATA)>
+<!ELEMENT contact (contact-name?, (email|phone)+)>
+<!ATTLIST contact contact-role CDATA #IMPLIED>
+<!ELEMENT contact-name (surname?, given-names?)>
+<!ELEMENT surname (#PCDATA)>
+<!ELEMENT given-names (#PCDATA)>
+<!ELEMENT email (#PCDATA)>
+<!ELEMENT phone (#PCDATA)>
+<!ELEMENT publication (publication-title, acronym?, contact?)>
+<!ATTLIST publication type CDATA #IMPLIED>
+<!ELEMENT publication-title (#PCDATA)>
+<!ELEMENT acronym (#PCDATA)>
+<!ELEMENT security (authentication-code)>
+<!ELEMENT authentication-code (#PCDATA)>
+<!ELEMENT destination (service-provider, publication, security?)>
+<!-- The processing instructions tag is a placeholder for implementation-specific instructions between vendors and publishers-->
+<!ELEMENT processing-instructions (processing-instruction*, processing-comments?)>
+<!ELEMENT processing-instruction (#PCDATA)>
+<!ATTLIST processing-instruction processing-sequence CDATA #IMPLIED>
+<!ELEMENT processing-comments (#PCDATA)>


### PR DESCRIPTION
This commit adds the XML example and DTD content I extracted from the NISO MECA 2.0 PDF (https://groups.niso.org/apps/group_public/download.php/23902/NISO_RP-30-2020_Manuscript_Exchange_Common_Approach_MECA.pdf).

There were several corrections required to get these to validate:
- In several places smart quotes had crept into the XML and DTD content, probably due to copy/paste
- The namespaces in the sample XML files don't match what's specified in the DTDs (e.g. `https://manuscriptexchange.org/schema/reviews` vs `https://manuscriptexchange.org/schema/reviews`); I went with the `manuscriptexchange.org` form (no `www.` prefix).
- The DTD filenames in the sample XML files don't match the DTD self-description (e.g. `transfer-1.0.dtd` vs. `MECA_transfer.dtd`). I went with the `transfer-1.0.dtd` form.
- (I set paths to the schema files relative to the locations of the example files.)

My goal is to get the MECA 2.0 spec into github (and out of the PDF) as-is, but those changes were required to get the XML to validate. If someone who was involved with the MECA 2.0 spec could review these, that would be much appreciated!

Incidentally, I'm confused about version numbers -- the PDF title refers to Version 2.0, but the DTDs refer to 1.0, and the working group seems to refer to 1.0 as well. What is the preferred version number for the current MECA spec, and if it's 2.0, is there a 1.0 that should be captured in github (e.g. on its own branch)?